### PR TITLE
PT-2234: support multiplatform watch; exclude directories from watch

### DIFF
--- a/src/commands/veloce/debug/watch.ts
+++ b/src/commands/veloce/debug/watch.ts
@@ -77,11 +77,11 @@ export default class Org extends DebugSfdxCommand {
         return;
       }
 
-      var filePath
+      let filePath;
       if (process.platform === 'darwin') {
         filePath = path.replace(`${workDir}/`, '');
       } else {
-        filePath = description.watchedPath
+        filePath = description.watchedPath;
       }
 
       if (lstatSync(filePath).isDirectory()) {


### PR DESCRIPTION
Make filepath determination platform-dependent, because on
linux systems path equal to filename, not absolute path, like
on macos.
Exclude directories change events