### PR TITLE
[PT-7303][fix] pull/push procedure rules regarding changes in release R6

### DIFF
--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -9,3 +9,25 @@ export interface CreateResult {
 export interface OrgInfo {
   BackendURL: string;
 }
+
+export interface SubscriberPackage {
+  Id: string;
+  Name: string;
+  NamespacePrefix: string;
+}
+
+export interface SubscriberPackageVersion {
+  Id: string;
+  Name: string;
+  MajorVersion: number;
+  MinorVersion: number;
+  PatchVersion: number;
+}
+
+export interface InstalledSubscriberPackage {
+  Id: string;
+  SubscriberPackageId: string;
+  SubscriberPackage: SubscriberPackage;
+  SubscriberPackageVersionId: string;
+  SubscriberPackageVersion: SubscriberPackageVersion;
+}

--- a/src/types/rule.types.ts
+++ b/src/types/rule.types.ts
@@ -41,7 +41,7 @@ export interface SFProcedureRuleTransformation {
   VELOCPQ__ResultPath__c: string;
   VELOCPQ__JavaScript__c: string;
   VELOCPQ__Expression__c: string;
-  VELOCPQ__ScriptJsId__c: string;
+  VELOCPQ__ScriptJsId__c?: string;
 }
 
 export interface SFProcedureRuleMapping {

--- a/src/types/rule.types.ts
+++ b/src/types/rule.types.ts
@@ -41,6 +41,7 @@ export interface SFProcedureRuleTransformation {
   VELOCPQ__ResultPath__c: string;
   VELOCPQ__JavaScript__c: string;
   VELOCPQ__Expression__c: string;
+  VELOCPQ__ScriptJsId__c: string;
 }
 
 export interface SFProcedureRuleMapping {

--- a/src/utils/common.utils.ts
+++ b/src/utils/common.utils.ts
@@ -1,6 +1,8 @@
 import { readFileSync, existsSync, mkdirSync, writeFileSync, readdirSync, WriteFileOptions } from 'fs';
 import { exec as nodeExec } from 'node:child_process';
+import { Connection } from '@salesforce/core';
 import { UX } from '@salesforce/command';
+import { InstalledSubscriberPackage } from '../types/common.types';
 import { SalesforceEntity } from '../types/salesforceEntity';
 
 export const exec = (cmd: string): Promise<string> => {
@@ -15,7 +17,7 @@ export const exec = (cmd: string): Promise<string> => {
   });
 };
 
-export const readFileSafeBuffer = (path: string, options?: {flag?: string}): Buffer|undefined => {
+export const readFileSafeBuffer = (path: string, options?: { flag?: string }): Buffer | undefined => {
   try {
     return readFileSync(path, options);
   } catch (err) {
@@ -41,7 +43,12 @@ export const parseJsonSafe = (str: string): any | undefined => {
   }
 };
 
-export const writeFileSafe = (dir: string, filename: string, data: string|Buffer, options?: WriteFileOptions): void => {
+export const writeFileSafe = (
+  dir: string,
+  filename: string,
+  data: string | Buffer,
+  options?: WriteFileOptions,
+): void => {
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
@@ -110,4 +117,81 @@ export const validSFID = (input: string): boolean => {
   }
 
   return String.fromCharCode(chars[0], chars[1], chars[2]) === input.substr(15, 3);
+};
+
+export const getInstalledPackageReleaseVersion = async (conn: Connection): Promise<string | undefined> => {
+  const result = await conn.tooling.autoFetchQuery<InstalledSubscriberPackage>(
+    `SELECT Id,SubscriberPackage.Name,SubscriberPackage.NamespacePrefix,SubscriberPackageVersion.Name,
+       SubscriberPackageVersion.MajorVersion,SubscriberPackageVersion.MinorVersion,SubscriberPackageVersion.PatchVersion
+FROM InstalledSubscriberPackage`,
+  );
+  return result?.records
+    ?.filter((rr) => rr.SubscriberPackage.NamespacePrefix === 'VELOCPQ')
+    .map(({ SubscriberPackageVersion }) => SubscriberPackageVersion)
+    .sort((l, r) => {
+      if (r.MajorVersion !== l.MajorVersion) {
+        return r.MajorVersion - l.MajorVersion;
+      }
+      if (r.MinorVersion !== l.MinorVersion) {
+        return r.MinorVersion - l.MinorVersion;
+      }
+      if (r.PatchVersion !== l.PatchVersion) {
+        return r.PatchVersion - l.PatchVersion;
+      }
+      return r.Name.localeCompare(l.Name);
+    })?.[0]?.Name;
+};
+
+/* i.e. 2023.R6.1.0 or 2023.R6-SNAPSHOT */
+export const versionPattern = /(?<year>[0-9]+)\.R(?<major>[0-9]+)(\.(?<minor>[0-9]+)\.(?<patch>[0-9]+)|-SNAPSHOT)/g;
+/*
+ * isInstalledVersionBetween checks installed Veloce Advanced CPQ version for compatibility
+ */
+export const isInstalledVersionBetween = async (
+  conn: Connection,
+  fromVersion: string,
+  toVersion?: string,
+): Promise<boolean> => {
+  const installedVersion = await getInstalledPackageReleaseVersion(conn);
+  if (installedVersion) {
+    const fromParts = versionPattern.exec(fromVersion);
+    const toParts = versionPattern.exec(toVersion ?? '');
+    const installedParts = versionPattern.exec(installedVersion);
+    if (installedParts) {
+      if (!installedParts.groups?.['minor']) {
+        // SNAPSHOT
+        // compare strings ('year' + 'major')
+        if (
+          Number(concatParts(installedParts, ['year', 'major'])) < Number(concatParts(fromParts, ['year', 'major'])) ||
+          (toParts &&
+            Number(concatParts(installedParts, ['year', 'major'])) > Number(concatParts(toParts, ['year', 'major'])))
+        ) {
+          return false;
+        }
+        return true;
+      } else {
+        // Release
+        // compare strings ('year' + 'major' + 'minor' + 'patch')
+        if (
+          Number(concatParts(installedParts, ['year', 'major', 'minor', 'patch'])) <
+            Number(concatParts(fromParts, ['year', 'major', 'minor', 'patch'])) ||
+          (toParts &&
+            Number(concatParts(installedParts, ['year', 'major', 'minor', 'patch'])) >
+              Number(concatParts(toParts, ['year', 'major', 'minor', 'patch'])))
+        ) {
+          return false;
+        }
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+const concatParts = (arr: RegExpExecArray | null, parts: string[]): string => {
+  let result = '';
+  for (const part of parts) {
+    result += arr?.groups?.[part] ?? '';
+  }
+  return result;
 };


### PR DESCRIPTION
JavaScript transformation of procedure rules are stored in Documents instead of linked user files starting from release R6.
Added logic to check for installed Veloce Advanced CPQ package version and use different ways to store JavaScript transformation content for different package versions.