### PR TITLE
[VLRL][add] support of old json id-map for procedure groups/rules

### DIFF
--- a/src/commands/veloce/source/push.ts
+++ b/src/commands/veloce/source/push.ts
@@ -92,7 +92,13 @@ export default class Push extends SfdxCommand {
 
     const drlRecords = await pushDRL({ idmap, rootPath, conn, member: memberMap.get('drl') });
 
-    const rule = await pushRule({ idmap, rootPath, conn, member: memberMap.get('rule') });
+    const rule = await pushRule({
+      idmap,
+      rootPath,
+      conn,
+      member: memberMap.get('rule'),
+      skipDelete: this.flags.skipdelete,
+    });
 
     const pmlRecords = await pushModel({ idmap, rootPath, conn, member: memberMap.get('model') });
 
@@ -108,6 +114,7 @@ export default class Push extends SfdxCommand {
 
     const docTemplateRecords = await pushDocTemplates({ idmap, rootPath, conn, member: memberMap.get('doc-template') });
 
+    ctx.storeIdmap(idmapPath);
     await saveIdMap(conn, idmap);
 
     // Return an object to be displayed with --json

--- a/src/common/idmap.json.ts
+++ b/src/common/idmap.json.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import { getContext } from '../utils/context';
 import { IdMap } from '../types/idmap';
 
@@ -19,6 +19,22 @@ export class IdMapJson {
     } catch (e) {
       ctx.ux.error(`IDMAP: Failed to load JSON file from ${path}`);
     }
+  }
+
+  public saveToPath(path: string): void {
+    const ctx = getContext();
+    ctx.ux.log(`IDMAP: Storing to ${path}`);
+
+    try {
+      writeFileSync(path, JSON.stringify(this.idmap, null, 2), { encoding: 'utf-8' });
+    } catch (e) {
+      ctx.ux.error(`IDMAP: Failed to store id-map JSON to file ${path}`);
+    }
+  }
+
+  public put(oldId: string, newId: string): void {
+    this.idmap[oldId] = newId;
+    this.reverseIdmap[newId] = oldId;
   }
 
   public get(id: string): string {

--- a/src/types/rule.types.ts
+++ b/src/types/rule.types.ts
@@ -92,6 +92,7 @@ export const RuleObjectTypes: { [key: string]: string } = {
 };
 
 export interface RuleGroup {
+  id?: string;
   referenceId: string;
   name: string;
   type: string;
@@ -104,6 +105,7 @@ export interface RuleGroup {
 }
 
 export interface Rule {
+  id?: string;
   referenceId?: string;
   name?: string;
   sequence?: number;

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -18,6 +18,14 @@ export class Context {
     this.idmap = new IdMapJson(path);
   }
 
+  public storeIdmap(path?: string | null): void {
+    if (!path || !this.idmap) {
+      return;
+    }
+
+    this.idmap.saveToPath(path);
+  }
+
   public get ux(): UX {
     const pCmd = this.cmd as any as PublicSfdxCommand;
 

--- a/src/utils/rule.utils.ts
+++ b/src/utils/rule.utils.ts
@@ -190,7 +190,7 @@ const saveToJSON = (procedureRules: SFProcedureRule[], pathToSave: string): void
   writeFileSafe(
     pathToSave,
     `${VELOCPQ__RuleGroupId__r.VELOCPQ__Type__c}_${VELOCPQ__RuleGroupId__r.Name}.json`,
-    JSON.stringify(generatedJSON),
+    JSON.stringify(generatedJSON, null, 2),
     {
       flag: 'w+',
     },


### PR DESCRIPTION
Use old json id-map if path was provided to command with flag `-I`, and use SF-based if path is not provided.